### PR TITLE
collect unmatched tokens

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -7,18 +7,23 @@ function parse(str) {
   var parser = new nearley.Parser(grammar.ParserRules, grammar.ParserStart, { keepHistory: true });
   var words = str.split(' ');
   var info = parser.save();
-  return words.reduce(function (prev, word) {
+  var unmatched = [];
+  var matched = words.reduce(function (prev, word) {
     word = word.replace(/,|;/, '') + ' ';
     //if it fails, roll it back
     try {
       parser.feed(word);
     } catch (e) {
+      unmatched.push(word.trim());
       parser.restore(info);
     }
     info = parser.save();
     //return the latest valid result
     return parser.results[0] || prev;
   }, {});
+
+  matched.unmatched = unmatched;
+  return matched;
 }
 
 module.exports = parse;

--- a/src/parse.js
+++ b/src/parse.js
@@ -9,18 +9,23 @@ function parse(str) {
   )
   const words = str.split(' ')
   let info = parser.save()
-  return words.reduce((prev, word) => {
+  let unmatched = []
+  let matched = words.reduce((prev, word) => {
     word = word.replace(/,|;/, '') + ' '
     //if it fails, roll it back
     try {
       parser.feed(word)
     } catch(e) {
+      unmatched.push(word.trim())
       parser.restore(info)
     }
     info = parser.save()
     //return the latest valid result
     return parser.results[0] || prev
   }, {})
+
+  matched.unmatched = unmatched
+  return matched
 }
 
 module.exports = parse

--- a/test/test_parse.js
+++ b/test/test_parse.js
@@ -73,24 +73,29 @@ describe('SMD Capacitors', () => {
     assert(c.type === 'capacitor')
     assert(c.capacitance === 100e-9, 'capacitance is wrong')
     assert(c.size === '0603', 'size is wrong')
+    assert(c.unmatched.join(' ') === 'kajdlkja alkdjlkajd')
   })
   it('ignores extra words 2', () => {
     const c = parse('adjalkjd 100nF akjdlkjda 0603 kajdlkja alkdjlkajd')
     assert(c.type === 'capacitor')
     assert(c.capacitance === 100e-9, 'capacitance is wrong')
     assert(c.size === '0603', 'size is wrong')
+    assert(c.unmatched.join(' ') === 'adjalkjd akjdlkjda kajdlkja alkdjlkajd')
   })
   it('ignores extra words 3', () => {
     const c = parse('capacitor 100nF 0603, warehouse 5')
     assert(c.type === 'capacitor')
     assert(c.capacitance === 100e-9, 'capacitance is wrong')
     assert(c.size === '0603', 'size is wrong')
+    // maybe should be `, warehouse 5`
+    assert(c.unmatched.join(' ') === 'warehouse')
   })
   it('ignores extra words 4', () => {
     const c = parse('adjalkjd 0603 akjdlkjda 100nF kajdlkja alkdjlkajd')
     assert(c.type === 'capacitor')
     assert(c.capacitance === 100e-9, 'capacitance is wrong')
     assert(c.size === '0603', 'size is wrong')
+    assert(c.unmatched.join(' ') === 'adjalkjd akjdlkjda kajdlkja alkdjlkajd')
   })
   it('parses characteristic X7R', () => {
     const c = parse('100nF 0603 X7R')


### PR DESCRIPTION
Hello Kaspar,

One thing that might be nice is the ability to collect the extraneous tokens, so that if user enters `100nF 0603 50V Kemet`, the `Kemet` token could be used for full text search.

This is a pretty hack-y way to do it, and it breaks the return behavior of `{}` for no match.  I've not used Nearly before, so believe there is probably a better way to do this, but thought I would create PR just to get your thoughts.