### PR TITLE
Allow wiggle room in SI prefixes that won't be ambiguous

### DIFF
--- a/src/metric_prefix.ne
+++ b/src/metric_prefix.ne
@@ -1,17 +1,17 @@
 @include "letters.ne"
 
-exa   -> "E" | E X A
+exa   ->  E  | E X A
 peta  -> "P" | P E T A
-tera  -> "T" | T E R A
-giga  -> "G" | G I G A
+tera  ->  T  | T E R A
+giga  ->  G  | G I G A
 mega  -> "M" | M E G A
-kilo  -> "k" | K I L O
-hecto -> "h" | H E C T O
-deci  -> "d" | D E C I
-centi -> "c" | C E N T I
+kilo  ->  K  | K I L O
+hecto ->  H  | H E C T O
+deci  ->  D  | D E C I
+centi ->  C  | C E N T I
 milli -> "m" | M I L L I
 micro ->
-    "u"
+     U
   | [\u03BC]
   | [\u00B5]
   | [\uD835] [\uDECD]
@@ -20,7 +20,7 @@ micro ->
   | [\uD835] [\uDF7B]
   | [\uD835] [\uDFB5]
   | M I C R O
-nano  -> "n" | N A N O
+nano  ->  N  | N A N O
 pico  -> "p" | P I C O
-femto -> "f" | F E M T O
-atto  -> "a" | A T T O
+femto ->  F  | F E M T O
+atto  ->  A  | A T T O


### PR DESCRIPTION
Resolves: https://github.com/kitspace/electro-grammar/issues/18

Untested :)